### PR TITLE
:bug: Convert the command name in lowercase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist-ssr
 *.local
 package-lock.json
 .idea/
+.replit

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 dist-ssr
 *.local
 package-lock.json
+.idea/

--- a/src/components/CreateSlashCommand.vue
+++ b/src/components/CreateSlashCommand.vue
@@ -101,7 +101,8 @@ export default {
             const commandNameMaxLength = this.name.length > 32;
             if (commandNameMaxLength) return 'Name can not be longer than 32 characters.';
             const invalidCharacters = !(/^[0-9a-zA-Z_]+$/.test(this.name));
-            if (this.name == this.name.toUpperCase()) return 'Name can not contain uppercase letter!';
+            const isUpperCase = (string) => /^[A-Z]*$/.test(string)
+            if (isUpperCase(this.name)) return 'Name can not contain uppercase letters!'
             if (invalidCharacters) return 'Name contains invalid characters.';
             return null;
         },

--- a/src/components/CreateSlashCommand.vue
+++ b/src/components/CreateSlashCommand.vue
@@ -94,6 +94,7 @@ export default {
         commandNameInputError () {
             const commandNameEmpty = this.name.length === 0;
             if (commandNameEmpty) return 'Name is required!';
+            this.name = this.name.toLowerCase()
             const commandExists = this.$store.state.commands.some((cmd) => cmd.name === this.name);
             if (commandExists) return 'There is already a command with that name!';
             const commandNameMinLength = this.name.length < 3;
@@ -101,8 +102,6 @@ export default {
             const commandNameMaxLength = this.name.length > 32;
             if (commandNameMaxLength) return 'Name can not be longer than 32 characters.';
             const invalidCharacters = !(/^[0-9a-zA-Z_]+$/.test(this.name));
-            const isUpperCase = (string) => /^[A-Z]*$/.test(string)
-            if (isUpperCase(this.name)) return 'Name can not contain uppercase letters!'
             if (invalidCharacters) return 'Name contains invalid characters.';
             return null;
         },

--- a/src/components/CreateSlashCommand.vue
+++ b/src/components/CreateSlashCommand.vue
@@ -101,6 +101,7 @@ export default {
             const commandNameMaxLength = this.name.length > 32;
             if (commandNameMaxLength) return 'Name can not be longer than 32 characters.';
             const invalidCharacters = !(/^[0-9a-zA-Z_]+$/.test(this.name));
+            if (this.name == this.name.toUpperCase()) return 'Name can not contain uppercase letter!';
             if (invalidCharacters) return 'Name contains invalid characters.';
             return null;
         },


### PR DESCRIPTION
This PR will add a verification if the name is Uppercased.
Sorry the GIF is ugly and I don’t show you it but you can test the website here: https://slash-command-gui.netlify.app/ (it is the same url without the ‘s’ at command)
[Video example](https://cdn.yanjobs.me/cdn/slash/video.MP4)